### PR TITLE
Completed/archived states for var colours

### DIFF
--- a/lib/varieties.css
+++ b/lib/varieties.css
@@ -19,6 +19,22 @@
   --vc-feedback: #EF9736;
   --vc-conversation: #536487;
   --vc-workshop: #AC80CB;
+
+  /* Completed/Archived State */
+  --vc-celebration-completed: color(var(--vc-celebration) a(60%));
+  --vc-lesson-completed: color(var(--vc-lesson) a(60%));
+  --vc-habit-completed: color(var(--vc-habit) a(60%));
+  --vc-form-completed: color(var(--vc-form) a(60%));
+  --vc-review-completed: color(var(--vc-review) a(60%));
+  --vc-intake-completed: color(var(--vc-intake) a(60%));
+  --vc-exam-completed: color(var(--vc-exam) a(60%));
+  --vc-caseStudy-completed: color(var(--vc-caseStudy) a(60%));
+  --vc-measurement-completed: color(var(--vc-measurement) a(60%));
+  --vc-quiz-completed: color(var(--vc-quiz) a(60%));
+  --vc-workout-completed: color(var(--vc-workout) a(60%));
+  --vc-feedback-completed: color(var(--vc-feedback) a(60%));
+  --vc-conversation-completed: color(var(--vc-conversation) a(60%));
+  --vc-workshop-completed: color(var(--vc-workshop) a(60%));
 }
 
 @each $variety, $bumpyName


### PR DESCRIPTION
The new archive design in PD-209 (https://github.com/PrecisionNutrition/es-student/pull/783) requires these in a situation where opacity wasn't going to work effectively. I figured it'd be helpful to make them globally available.