### PR TITLE
[BS-165] adds `resource` and `practice` varieties

### DIFF
--- a/lib/varieties.css
+++ b/lib/varieties.css
@@ -21,6 +21,8 @@
   --vc-workshop: #00c853;
   --vc-journal: #ff6196;
   --vc-study: #00b8f0;
+  --vc-practice: #00b8f0;
+  --vc-resource: #00c853;
 
   --vc-celebration-lighter: color-mod(var(--vc-celebration) tint(75%));
   --vc-lesson-lighter: color-mod(var(--vc-lesson) tint(75%));
@@ -38,6 +40,8 @@
   --vc-workshop-lighter: color-mod(var(--vc-workshop) tint(75%));
   --vc-journal-lighter: color-mod(var(--vc-journal) tint(75%));
   --vc-study-lighter: color-mod(var(--vc-study) tint(75%));
+  --vc-practice-lighter: color-mod(var(--vc-practice) tint(75%));
+  --vc-resource-lighter: color-mod(var(--vc-resource) tint(75%));
 
   --vc-celebration-lightest: color-mod(var(--vc-celebration) tint(90%));
   --vc-lesson-lightest: color-mod(var(--vc-lesson) tint(90%));
@@ -55,6 +59,8 @@
   --vc-workshop-lightest: color-mod(var(--vc-workshop) tint(90%));
   --vc-journal-lightest: color-mod(var(--vc-journal) tint(90%));
   --vc-study-lightest: color-mod(var(--vc-study) tint(90%));
+  --vc-practice-lightest: color-mod(var(--vc-practice) tint(90%));
+  --vc-resource-lightest: color-mod(var(--vc-resource) tint(90%));
 
   /* Completed/Archived State */
   --vc-celebration-completed: color-mod(var(--vc-celebration) tint(95%));
@@ -73,11 +79,13 @@
   --vc-workshop-completed: color-mod(var(--vc-workshop) tint(95%));
   --vc-journal-completed: color-mod(var(--vc-journal) tint(95%));
   --vc-study-completed: color-mod(var(--vc-study) tint(95%));
+  --vc-practice-completed: color-mod(var(--vc-practice) tint(95%));
+  --vc-resource-completed: color-mod(var(--vc-resource) tint(95%));
 }
 
 @each $variety, $bumpyName
-  in (celebration, lesson, form, review, intake, exam, caseStudy, measurement, quiz, workout, habit, feedback, conversation, workshop, journal, study),
-     (Celebration, Lesson, Form, Review, Intake, Exam, CaseStudy, Measurement, Quiz, Workout, Habit, Feedback, Conversation, Workshop, Journal, Study) {
+  in (celebration, lesson, form, review, intake, exam, caseStudy, measurement, quiz, workout, habit, feedback, conversation, workshop, journal, study, practice, resource),
+     (Celebration, Lesson, Form, Review, Intake, Exam, CaseStudy, Measurement, Quiz, Workout, Habit, Feedback, Conversation, Workshop, Journal, Study, Practice, Resource) {
 
   .u-colour$(bumpyName) {
     color: var(--vc-$(variety)) !important;


### PR DESCRIPTION
As per the description on the parent ticket:

```
Practice variety colour & icon are the same as habit, for now 
Resource variety colour & icon are the same as lesson, for now
```
parent: https://precisionnutrition.atlassian.net/browse/BS-134
specs: https://precisionnutrition.atlassian.net/browse/BS-165